### PR TITLE
Turn on formatting

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -11,7 +11,15 @@ on:
       - '**.py'
 
 jobs:
+  qa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - uses: pre-commit/action@v3.0.1
+
   test:
+    needs: qa
     runs-on: ubuntu-latest
 
     strategy:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ The space for contribution is HUGE and OPEN! For instance:
 
 Feel free to reach out, or directly fork, change, and create pull requests, or create new branches to contribute.
 
+All contributed code should be formatted and linted with `ruff`. We use `pre-commit` to make sure all commits satisfy this requirement. To use this run:
+```
+pre-commit install
+```
+You can also manually perform the formatting using:
+```
+pre-commit run --all-files
+```
+
 ### License
 
 [MIT LICENSE](https://github.com/bioatmosphere/DEMENTpy/blob/master/LICENSE)


### PR DESCRIPTION
Added pre-commit instructions to README and the formatting / linting to the CI workflow.

The pre-commit config still needs to be renamed to '.pre-commit-config.yaml' but we should first wait until we merge some branches (mentioned in #30) and then rebase to reduce inevitable conflicts due to the formatting.

Closes #30